### PR TITLE
Improve automatic legend placement

### DIFF
--- a/depict/core/histogram.py
+++ b/depict/core/histogram.py
@@ -1,3 +1,4 @@
+from .legend import place_legend_without_overlap
 from .plot import Plot
 from .tools import show_base, save_base, is_color, format_color, is_iterable
 from ..tools.color_palettes import palette_from_name_to_function
@@ -23,6 +24,9 @@ def histogram_base(x, y, source_dataframe, tick_label, label_orientation,
         x (array-like): X-axis data
         y (array-like): y-axis data
     """
+    user_defined_x_range = x_range is not None
+    user_defined_y_range = y_range is not None
+
     # We convert (source, x and y) into only x and y. x and y will be processed
     # normally. source will not be used any more.
     if source_dataframe is not None:
@@ -327,6 +331,17 @@ def histogram_base(x, y, source_dataframe, tick_label, label_orientation,
         def make_legend_interactive(f):
             f.legend.click_policy = "hide"
         steps.append(make_legend_interactive)
+
+        def place_legend(f, x_data=x, y_data=y,
+                         x_range_set=user_defined_x_range,
+                         y_range_set=user_defined_y_range):
+            place_legend_without_overlap(
+                fig=f, x_arrays=x_data, y_arrays=y_data,
+                user_defined_x_range=x_range_set,
+                user_defined_y_range=y_range_set,
+            )
+
+        steps.append(place_legend)
 
     def format_ticks(f, x_axis_type_c=x_axis_type, x_copy_c=x_copy,
                      major_label_overrides_c=major_label_overrides):

--- a/depict/core/legend.py
+++ b/depict/core/legend.py
@@ -1,0 +1,98 @@
+"""Utilities to position legends without overlapping plotted data."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Sequence
+
+import numpy as np
+from bokeh.models import Range1d
+
+
+def _as_array(values: Iterable) -> np.ndarray:
+    arr = np.array(values)
+    if arr.dtype.kind == "M":
+        return arr.astype("datetime64[ns]")
+    return arr
+
+
+def _numeric_view(values: np.ndarray) -> np.ndarray:
+    if values.dtype.kind == "M":
+        return values.astype("datetime64[ns]").astype("int64")
+    return values.astype(float)
+
+
+def _compute_bounds(arrays: Sequence[Iterable]):
+    flattened = np.concatenate([_as_array(a) for a in arrays])
+    numeric = _numeric_view(flattened)
+    arr_min = flattened.min()
+    arr_max = flattened.max()
+    span = arr_max - arr_min
+    return {
+        "raw_min": arr_min,
+        "raw_max": arr_max,
+        "numeric": numeric,
+        "span": span,
+        "is_datetime": flattened.dtype.kind == "M",
+    }
+
+
+def _padding(span, is_datetime: bool):
+    if is_datetime:
+        span_ns = int(span.astype("timedelta64[ns]").astype(int)) if span != 0 else 0
+        span_ns = span_ns if span_ns else 1
+        return np.timedelta64(int(span_ns * 0.1) or 1, "ns")
+    span = float(span)
+    span = span if span != 0 else 1.0
+    return span * 0.1
+
+
+def _choose_corner(x_numeric: np.ndarray, y_numeric: np.ndarray):
+    x_mid = (x_numeric.min() + x_numeric.max()) / 2
+    y_mid = (y_numeric.min() + y_numeric.max()) / 2
+
+    quadrants = {
+        "top_left": (x_numeric < x_mid) & (y_numeric > y_mid),
+        "top_right": (x_numeric >= x_mid) & (y_numeric > y_mid),
+        "bottom_left": (x_numeric < x_mid) & (y_numeric <= y_mid),
+        "bottom_right": (x_numeric >= x_mid) & (y_numeric <= y_mid),
+    }
+    counts = {name: int(mask.sum()) for name, mask in quadrants.items()}
+    best_corner = min(counts, key=counts.get)
+    return best_corner, counts[best_corner] == 0
+
+
+def place_legend_without_overlap(fig, x_arrays: List[Iterable], y_arrays: List[Iterable],
+                                 user_defined_x_range: bool, user_defined_y_range: bool):
+    if not fig.legend:
+        return
+
+    x_bounds = _compute_bounds(x_arrays)
+    y_bounds = _compute_bounds(y_arrays)
+
+    corner, empty_corner = _choose_corner(x_bounds["numeric"], y_bounds["numeric"])
+
+    for legend in fig.legend:
+        legend.location = corner
+
+    if empty_corner:
+        return
+
+    if not user_defined_x_range:
+        x_pad = _padding(x_bounds["span"], x_bounds["is_datetime"])
+        left = x_bounds["raw_min"]
+        right = x_bounds["raw_max"]
+        if corner.endswith("right"):
+            right = right + x_pad
+        else:
+            left = left - x_pad
+        fig.x_range = Range1d(left, right)
+
+    if not user_defined_y_range:
+        y_pad = _padding(y_bounds["span"], y_bounds["is_datetime"])
+        bottom = y_bounds["raw_min"]
+        top = y_bounds["raw_max"]
+        if corner.startswith("top"):
+            top = top + y_pad
+        else:
+            bottom = bottom - y_pad
+        fig.y_range = Range1d(bottom, top)

--- a/depict/core/line.py
+++ b/depict/core/line.py
@@ -1,3 +1,4 @@
+from .legend import place_legend_without_overlap
 from .plot import Plot
 from .tools import show_base, save_base, is_color, format_color, is_iterable
 from ..tools.color_palettes import palette_from_name_to_function
@@ -23,6 +24,9 @@ def line_base(y, x, source_dataframe, width, height, description, title,
         x_range (array-like) Range of the x-axis. E.g. `[0, 1]`
         y_range (array-like) Range of the y-axis. E.g. `[0, 1]`
     """
+    user_defined_x_range = x_range is not None
+    user_defined_y_range = y_range is not None
+
     # We convert (source, x and y) into only x and y. x and y will be processed
     # normally. source will not be used any more.
     if source_dataframe is not None:
@@ -319,6 +323,17 @@ def line_base(y, x, source_dataframe, width, height, description, title,
         def make_legend_interactive(f):
             f.legend.click_policy = "hide"
         steps.append(make_legend_interactive)
+
+        def place_legend(f, x_data=x, y_data=y,
+                         x_range_set=user_defined_x_range,
+                         y_range_set=user_defined_y_range):
+            place_legend_without_overlap(
+                fig=f, x_arrays=x_data, y_arrays=y_data,
+                user_defined_x_range=x_range_set,
+                user_defined_y_range=y_range_set,
+            )
+
+        steps.append(place_legend)
 
     if fill_between:
         if len(y) == 1:

--- a/depict/core/point.py
+++ b/depict/core/point.py
@@ -1,3 +1,4 @@
+from .legend import place_legend_without_overlap
 from .plot import Plot
 from .tools import show_base, save_base, is_color, format_color, is_iterable
 from ..tools.color_palettes import palette_from_name_to_function
@@ -21,6 +22,9 @@ def point_base(x, y, source_dataframe, width, height, description, title,
         x (array-like): X-axis data
         y (array-like): y-axis data
     """
+    user_defined_x_range = x_range is not None
+    user_defined_y_range = y_range is not None
+
     # We convert (source, x and y) into only x and y. x and y will be processed
     # normally. source will not be used any more.
     if source_dataframe is not None:
@@ -255,6 +259,17 @@ def point_base(x, y, source_dataframe, width, height, description, title,
         def make_legend_interactive(f):
             f.legend.click_policy = "hide"
         steps.append(make_legend_interactive)
+
+        def place_legend(f, x_data=x, y_data=y,
+                         x_range_set=user_defined_x_range,
+                         y_range_set=user_defined_y_range):
+            place_legend_without_overlap(
+                fig=f, x_arrays=x_data, y_arrays=y_data,
+                user_defined_x_range=x_range_set,
+                user_defined_y_range=y_range_set,
+            )
+
+        steps.append(place_legend)
 
     def _make_fig():
         fig = figure(width=width, height=height, title=title,


### PR DESCRIPTION
## Summary
- add shared legend placement helper to avoid overlapping plotted data
- apply automatic legend positioning and optional axis padding to line, scatter, and histogram plots

## Testing
- python -m pytest tests/unit/test_examples_readme.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d6416d68c8333ae6577e002137b8a)